### PR TITLE
Add Cygwin rebase step to ubcp build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -213,6 +213,35 @@ jobs:
           #exit $exitCode
           #}
 
+      - name: rebase! cygwin DLLs (if needed)
+        shell: pwsh
+        timeout-minutes: 60
+        run: |
+          $candidateRoots = @(
+            (Resolve-Path './_local/ubcp/cygwin' -ErrorAction SilentlyContinue),
+            'C:\core\infrastructure\ubcp\cygwin'
+          ) | Where-Object { $_ }
+
+          $dashPath = $null
+          foreach ($root in $candidateRoots) {
+            $dash = Join-Path $root 'bin' 'dash.exe'
+            if (Test-Path $dash) {
+              $dashPath = $dash
+              break
+            }
+          }
+
+          if (-not $dashPath) {
+            Write-Host "dash.exe not found; skipping rebaseall."
+            exit 0
+          }
+
+          & $dashPath -c "/usr/bin/rebaseall" 2>&1 | Tee-Object -FilePath '/rebaseall.log'
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "##[error]rebaseall failed with exit code $LASTEXITCODE"
+            exit $LASTEXITCODE
+          }
+
       #- name: report! cygwin links
         #shell: pwsh
         #timeout-minutes: 240


### PR DESCRIPTION
## Summary
- add a rebase step to the ubcp Windows build to refresh Cygwin DLL bases when available
- capture rebaseall output to a log and surface failures clearly in the workflow

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69570fbb7fdc832cbc95a0638f919d34)